### PR TITLE
feat: Fetch missing posters from TMDB and cache

### DIFF
--- a/src/api/tmdb.py
+++ b/src/api/tmdb.py
@@ -4,6 +4,7 @@ from dotenv import load_dotenv
 
 class TMDBClient:
     BASE_URL = "https://api.themoviedb.org/3"
+    IMAGE_BASE_URL = "https://image.tmdb.org/t/p/"
 
     def __init__(self, api_key=None, read_access_token=None):
         # Load from .env if not provided
@@ -24,6 +25,14 @@ class TMDBClient:
         response = requests.get(url, params=params, headers=headers, timeout=10)
         response.raise_for_status()
         return response.json()
+
+    def get_full_poster_url(self, poster_path: str, size: str = 'w500') -> str | None:
+        if not poster_path:
+            return None
+        # Ensure poster_path does not start with a slash if IMAGE_BASE_URL ends with one.
+        if poster_path.startswith('/'):
+            poster_path = poster_path[1:]
+        return f"{self.IMAGE_BASE_URL}{size}/{poster_path}"
 
     def get_movie_details(self, tmdb_id):
         """Fetch movie details from TMDB by tmdb_id."""

--- a/src/ui/widgets/movie_details_widget.py
+++ b/src/ui/widgets/movie_details_widget.py
@@ -47,9 +47,36 @@ class MovieDetailsWidget(QWidget):
         self.poster = QLabel()
         self.poster.setAlignment(Qt.AlignTop)
         if self.movie.get('stream_icon'):
-            load_image_async(self.movie['stream_icon'], self.poster, QPixmap('assets/movies.png'), update_size=(180, 260))
+            load_image_async(self.movie['stream_icon'], self.poster, QPixmap('assets/movies.png'), update_size=(180, 260), main_window=self.main_window)
         else:
-            self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+            tmdb_id = self.movie.get('tmdb_id')
+            if tmdb_id and self.tmdb_client:
+                # print(f"[MovieDetailsWidget] stream_icon missing, attempting to fetch poster from TMDB using tmdb_id: {tmdb_id}") # Original debug log
+                try:
+                    details = self.tmdb_client.get_movie_details(tmdb_id)
+                    if details:
+                        poster_path = details.get('poster_path')
+                        if poster_path:
+                            tmdb_poster_url = self.tmdb_client.get_full_poster_url(poster_path)
+                            if tmdb_poster_url:
+                                # print(f"[MovieDetailsWidget] Found TMDB poster: {tmdb_poster_url}") # Original debug log
+                                self.movie['stream_icon'] = tmdb_poster_url
+                                load_image_async(tmdb_poster_url, self.poster, QPixmap('assets/movies.png'), update_size=(180, 260), main_window=self.main_window)
+                            else:
+                                # print(f"[MovieDetailsWidget] Failed to construct TMDB poster URL for tmdb_id: {tmdb_id}") # Original debug log
+                                self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+                        else:
+                            # print(f"[MovieDetailsWidget] No poster_path found in TMDB details for tmdb_id: {tmdb_id}") # Original debug log
+                            self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+                    else:
+                        # print(f"[MovieDetailsWidget] Failed to fetch details from TMDB for tmdb_id: {tmdb_id}") # Original debug log
+                        self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+                except Exception as e:
+                    # print(f"[MovieDetailsWidget] Error fetching details from TMDB for tmdb_id: {tmdb_id} - {e}") # Original debug log
+                    self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+            else:
+                # print(f"[MovieDetailsWidget] No tmdb_id or tmdb_client available to fetch poster.") # Original debug log
+                self.poster.setPixmap(QPixmap('assets/movies.png').scaled(180, 260, Qt.KeepAspectRatio, Qt.SmoothTransformation))
         # Overlay rated-r icon if movie is for adults
         if self.movie.get('adult'):
             rated_r_label = QLabel(self.poster)

--- a/test_scenario_1.py
+++ b/test_scenario_1.py
@@ -1,0 +1,78 @@
+import sys
+import os
+# Set Qt platform to offscreen BEFORE importing any Qt modules
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+# Add src to path to allow imports like src.api.tmdb
+sys.path.insert(0, '/app')
+
+from PyQt5.QtWidgets import QApplication, QLabel
+from PyQt5.QtGui import QPixmap
+from src.ui.widgets.movie_details_widget import MovieDetailsWidget
+from src.api.tmdb import TMDBClient
+from src.utils.image_cache import ImageCache # Import ImageCache to use its methods
+
+# Ensure TMDB_READACCESS_TOKEN is set for the test if TMDB_API_KEY is not
+os.environ['TMDB_READACCESS_TOKEN'] = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYjI5ZWU1NzcxMDIxZmNhNWE4NTE5YWRkMGE1NTQxMiIsInN1YiI6IjY2MjY1NTVjMzY2ODc1MDE3ZDNlNzM2YiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.7L6FpWp0U5XQ89J1W8fBq_kYc8dJq0pkp0j77O_uYdM"
+
+
+# Mock main_window and api_client
+class MockLoadingIconController:
+    def __init__(self):
+        self.show_icon = self._create_mock_signal("show_icon")
+        self.hide_icon = self._create_mock_signal("hide_icon")
+
+    def _create_mock_signal(self, name):
+        mock_signal_object = lambda: None 
+        mock_signal_object.emit = lambda: print(f"[TEST_LOG_MOCK] MockLoadingIconController.{name}.emit() called")
+        return mock_signal_object
+
+class MockMainWindow:
+    def __init__(self):
+        self.loading_icon_controller = MockLoadingIconController()
+        self.api_client = None
+
+# Initialize QApplication
+app = QApplication.instance() if QApplication.instance() else QApplication(sys.argv)
+
+print("[TEST_SCENARIO_1] START")
+
+movie_data_1 = {
+    'name': 'Fight Club',
+    'tmdb_id': 550 
+}
+print(f"[TEST_SCENARIO_1] Initial movie_data_1: {movie_data_1}")
+
+tmdb_client = TMDBClient() 
+mock_main_window = MockMainWindow()
+poster_label_container = QLabel() 
+
+widget_1 = MovieDetailsWidget(movie=movie_data_1.copy(), api_client=None, main_window=mock_main_window, tmdb_client=tmdb_client, parent=poster_label_container)
+
+print(f"[TEST_SCENARIO_1] Movie data after MovieDetailsWidget init: {widget_1.movie}")
+
+import time
+print("[TEST_SCENARIO_1] Waiting for image loading thread...")
+time.sleep(7) 
+
+print(f"[TEST_SCENARIO_1] Poster label pixmap null after wait: {widget_1.poster.pixmap().isNull()}")
+print(f"[TEST_SCENARIO_1] Movie data after wait: {widget_1.movie}")
+
+# Check cache content
+print("[TEST_SCENARIO_1] Checking cache content...")
+expected_poster_url = "https://image.tmdb.org/t/p/w500/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg"
+expected_cache_path = ImageCache.get_cache_path(expected_poster_url)
+print(f"[TEST_SCENARIO_1] Expected cache path: {expected_cache_path}")
+
+if os.path.exists(expected_cache_path):
+    print(f"[TEST_SCENARIO_1] SUCCESS: Expected poster image found in cache at {expected_cache_path}.")
+else:
+    print(f"[TEST_SCENARIO_1] FAILURE: Expected poster image NOT found in cache at {expected_cache_path}.")
+    # Listing directory content for debugging if file not found
+    cache_base_dir = "/app/assets/cache/images/"
+    if os.path.exists(cache_base_dir):
+        for root, dirs, files in os.walk(cache_base_dir):
+            print(f"[TEST_SCENARIO_1] Cache content - Root: {root}, Dirs: {dirs}, Files: {files}")
+
+print("[TEST_SCENARIO_1] END")
+

--- a/test_scenario_2.py
+++ b/test_scenario_2.py
@@ -1,0 +1,95 @@
+import sys
+import os
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+sys.path.insert(0, '/app')
+
+from PyQt5.QtWidgets import QApplication, QLabel
+from PyQt5.QtGui import QPixmap
+from src.ui.widgets.movie_details_widget import MovieDetailsWidget
+from src.api.tmdb import TMDBClient
+from src.utils.image_cache import ImageCache
+
+os.environ['TMDB_READACCESS_TOKEN'] = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYjI5ZWU1NzcxMDIxZmNhNWE4NTE5YWRkMGE1NTQxMiIsInN1YiI6IjY2MjY1NTVjMzY2ODc1MDE3ZDNlNzM2YiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.7L6FpWp0U5XQ89J1W8fBq_kYc8dJq0pkp0j77O_uYdM"
+
+class MockLoadingIconController:
+    def __init__(self, instance_name=""):
+        self.instance_name = instance_name
+        self.show_icon = self._create_mock_signal("show_icon")
+        self.hide_icon = self._create_mock_signal("hide_icon")
+
+    def _create_mock_signal(self, name):
+        mock_signal_object = lambda: None 
+        mock_signal_object.emit = lambda: print(f"[TEST_LOG_MOCK {self.instance_name}] MockLoadingIconController.{name}.emit() called")
+        return mock_signal_object
+
+class MockMainWindow:
+    def __init__(self, instance_name=""):
+        self.loading_icon_controller = MockLoadingIconController(instance_name)
+        self.api_client = None
+
+app = QApplication.instance() if QApplication.instance() else QApplication(sys.argv)
+
+print("[TEST_SCENARIO_2] START")
+
+movie_data = {
+    'name': 'Fight Club',
+    'tmdb_id': 550 
+}
+tmdb_poster_url = "https://image.tmdb.org/t/p/w500/pB8BM7pdSp6B6Ih7QZ4DrQ3PmJK.jpg"
+expected_cache_path = ImageCache.get_cache_path(tmdb_poster_url)
+
+
+# --- First Instantiation (to populate cache) ---
+print("\n[TEST_SCENARIO_2] --- First Instantiation ---")
+# Clear cache before the first run to ensure it's a download
+if os.path.exists(expected_cache_path):
+    os.remove(expected_cache_path)
+    print(f"[TEST_SCENARIO_2] Cleared specific cache file: {expected_cache_path}")
+# Ensure parent directories for the cache file exist for subsequent operations
+ImageCache.ensure_cache_dir() # This creates /app/assets/cache/images
+# We also need to ensure the specific subdirectories for TMDB urls are made if not existing
+# However, get_cache_path and subsequent save in load_image_async should handle this.
+
+tmdb_client = TMDBClient() 
+mock_main_window_1 = MockMainWindow("Instance1")
+poster_label_container_1 = QLabel() 
+
+widget_1 = MovieDetailsWidget(movie=movie_data.copy(), api_client=None, main_window=mock_main_window_1, tmdb_client=tmdb_client, parent=poster_label_container_1)
+print(f"[TEST_SCENARIO_2] Instance 1: Movie data after init: {widget_1.movie}")
+import time
+print("[TEST_SCENARIO_2] Instance 1: Waiting for image loading thread...")
+time.sleep(7) 
+print(f"[TEST_SCENARIO_2] Instance 1: Poster pixmap null after wait: {widget_1.poster.pixmap().isNull()}")
+if os.path.exists(expected_cache_path):
+    print(f"[TEST_SCENARIO_2] Instance 1: SUCCESS - Image found in cache at {expected_cache_path}")
+else:
+    print(f"[TEST_SCENARIO_2] Instance 1: FAILURE - Image NOT in cache at {expected_cache_path}")
+
+
+# --- Second Instantiation (should hit cache) ---
+print("\n[TEST_SCENARIO_2] --- Second Instantiation ---")
+# Movie data for the second instance should reflect that stream_icon was updated by the first
+# This simulates navigating away and back, where the application might re-fetch movie info
+# or use an updated movie object. For this test, we use the updated movie object from widget_1.
+movie_data_for_second_run = widget_1.movie.copy() 
+# Alternatively, if the movie object isn't updated globally, we could provide the original movie_data
+# and expect it to re-fetch from TMDB then hit the *download* cache if the URL is the same,
+# or hit the *pixmap* cache if load_image_async itself has an in-memory pixmap cache (it doesn't explicitly).
+# The key here is that the image_url given to load_image_async will be the TMDB one.
+
+mock_main_window_2 = MockMainWindow("Instance2")
+poster_label_container_2 = QLabel()
+
+# IMPORTANT: For the cache test to be valid, the second call to load_image_async
+# must use the *exact same image_url* that was used in the first call (which is now stored in widget_1.movie['stream_icon'])
+print(f"[TEST_SCENARIO_2] Instance 2: Initial movie data: {movie_data_for_second_run}")
+
+widget_2 = MovieDetailsWidget(movie=movie_data_for_second_run, api_client=None, main_window=mock_main_window_2, tmdb_client=tmdb_client, parent=poster_label_container_2)
+print(f"[TEST_SCENARIO_2] Instance 2: Movie data after init: {widget_2.movie}")
+# Less wait time needed if it's a cache hit, but worker thread still runs
+print("[TEST_SCENARIO_2] Instance 2: Waiting for image loading thread (should be quick if cached)...")
+time.sleep(1) # Shorter wait, cache hit should be fast
+print(f"[TEST_SCENARIO_2] Instance 2: Poster pixmap null after wait: {widget_2.poster.pixmap().isNull()}")
+
+print("[TEST_SCENARIO_2] END")
+

--- a/test_scenario_3.py
+++ b/test_scenario_3.py
@@ -1,0 +1,89 @@
+import sys
+import os
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+sys.path.insert(0, '/app')
+
+from PyQt5.QtWidgets import QApplication, QLabel
+from PyQt5.QtGui import QPixmap
+from src.ui.widgets.movie_details_widget import MovieDetailsWidget
+from src.api.tmdb import TMDBClient
+
+os.environ['TMDB_READACCESS_TOKEN'] = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYjI5ZWU1NzcxMDIxZmNhNWE4NTE5YWRkMGE1NTQxMiIsInN1YiI6IjY2MjY1NTVjMzY2ODc1MDE3ZDNlNzM2YiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.7L6FpWp0U5XQ89J1W8fBq_kYc8dJq0pkp0j77O_uYdM"
+
+class MockLoadingIconController:
+    def __init__(self, instance_name=""):
+        self.instance_name = instance_name
+        self.show_icon = self._create_mock_signal("show_icon")
+        self.hide_icon = self._create_mock_signal("hide_icon")
+
+    def _create_mock_signal(self, name):
+        mock_signal_object = lambda: None 
+        mock_signal_object.emit = lambda: print(f"[TEST_LOG_MOCK {self.instance_name}] MockLoadingIconController.{name}.emit() called")
+        return mock_signal_object
+
+class MockMainWindow:
+    def __init__(self, instance_name=""):
+        self.loading_icon_controller = MockLoadingIconController(instance_name)
+        self.api_client = None
+
+# Store original TMDBClient.get_movie_details
+original_get_movie_details = TMDBClient.get_movie_details
+
+def mock_get_movie_details_no_poster(self, tmdb_id):
+    print(f"[TEST_LOG_MOCK TMDBClient] mock_get_movie_details_no_poster called for tmdb_id: {tmdb_id}")
+    # Simulate a valid response but with no poster_path
+    # Using TMDB ID 551 (Hooligans) as an example, but forcing no poster.
+    if tmdb_id == 551: # Arbitrary ID for this test
+        return {
+            'adult': False, 'backdrop_path': '/xRyINp9KfMLVjRiO5nCsoRDdvvF.jpg', 
+            'id': tmdb_id, 'original_title': 'Movie With No Poster', 
+            'poster_path': None, # Key for this test
+            'overview': 'This movie exists but has no poster in this mock.',
+            'release_date': '2000-01-01'
+        }
+    # Fallback to original method if a different ID is somehow used
+    return original_get_movie_details(self, tmdb_id)
+
+app = QApplication.instance() if QApplication.instance() else QApplication(sys.argv)
+
+print("[TEST_SCENARIO_3] START")
+
+# --- Test Scenario 3 ---
+print("\n[TEST_SCENARIO_3] --- Movie with tmdb_id but TMDB returns no poster_path ---")
+
+movie_data_3 = {
+    'name': 'Movie With No Poster',
+    'tmdb_id': 551 # ID we will mock to have no poster
+}
+print(f"[TEST_SCENARIO_3] Initial movie_data_3: {movie_data_3}")
+
+# Apply the mock
+TMDBClient.get_movie_details = mock_get_movie_details_no_poster
+print("[TEST_SCENARIO_3] TMDBClient.get_movie_details has been mocked.")
+
+tmdb_client_mocked = TMDBClient()
+mock_main_window_3 = MockMainWindow("Instance3")
+poster_label_container_3 = QLabel() 
+
+widget_3 = MovieDetailsWidget(movie=movie_data_3.copy(), api_client=None, main_window=mock_main_window_3, tmdb_client=tmdb_client_mocked, parent=poster_label_container_3)
+print(f"[TEST_SCENARIO_3] Movie data after MovieDetailsWidget init: {widget_3.movie}")
+
+import time
+print("[TEST_SCENARIO_3] Waiting briefly (no download expected)...")
+time.sleep(1) # Shorter wait as no download should occur
+
+print(f"[TEST_SCENARIO_3] Poster label pixmap null after wait: {widget_3.poster.pixmap().isNull()}")
+# If the default placeholder is set, the pixmap won't be null if the placeholder file exists and is valid.
+# We check if stream_icon was updated. It should NOT be.
+print(f"[TEST_SCENARIO_3] Movie data after wait: {widget_3.movie}")
+if 'stream_icon' not in widget_3.movie or widget_3.movie['stream_icon'] is None:
+    print("[TEST_SCENARIO_3] SUCCESS: movie.stream_icon was not set with a TMDB URL.")
+else:
+    print(f"[TEST_SCENARIO_3] FAILURE: movie.stream_icon was unexpectedly set to: {widget_3.movie.get('stream_icon')}")
+
+# Restore original method
+TMDBClient.get_movie_details = original_get_movie_details
+print("[TEST_SCENARIO_3] TMDBClient.get_movie_details has been restored.")
+
+print("[TEST_SCENARIO_3] END")
+

--- a/test_scenario_4.py
+++ b/test_scenario_4.py
@@ -1,0 +1,77 @@
+import sys
+import os
+os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+sys.path.insert(0, '/app')
+
+from PyQt5.QtWidgets import QApplication, QLabel
+from PyQt5.QtGui import QPixmap
+from src.ui.widgets.movie_details_widget import MovieDetailsWidget
+# TMDBClient might not be strictly needed if it's not even constructed or called
+# but importing for consistency in test structure
+from src.api.tmdb import TMDBClient 
+
+os.environ['TMDB_READACCESS_TOKEN'] = "eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYjI5ZWU1NzcxMDIxZmNhNWE4NTE5YWRkMGE1NTQxMiIsInN1YiI6IjY2MjY1NTVjMzY2ODc1MDE3ZDNlNzM2YiIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.7L6FpWp0U5XQ89J1W8fBq_kYc8dJq0pkp0j77O_uYdM"
+
+class MockLoadingIconController:
+    def __init__(self, instance_name=""):
+        self.instance_name = instance_name
+        self.show_icon = self._create_mock_signal("show_icon")
+        self.hide_icon = self._create_mock_signal("hide_icon")
+
+    def _create_mock_signal(self, name):
+        mock_signal_object = lambda: None 
+        mock_signal_object.emit = lambda: print(f"[TEST_LOG_MOCK {self.instance_name}] MockLoadingIconController.{name}.emit() called")
+        return mock_signal_object
+
+class MockMainWindow:
+    def __init__(self, instance_name=""):
+        self.loading_icon_controller = MockLoadingIconController(instance_name)
+        self.api_client = None
+
+app = QApplication.instance() if QApplication.instance() else QApplication(sys.argv)
+
+print("[TEST_SCENARIO_4] START")
+
+# --- Test Scenario 4 ---
+print("\n[TEST_SCENARIO_4] --- Movie with no stream_icon and no tmdb_id ---")
+
+movie_data_4_a = {
+    'name': 'Movie With Nothing'
+    # stream_icon is missing
+    # tmdb_id is missing
+}
+print(f"[TEST_SCENARIO_4] Initial movie_data_4_a: {movie_data_4_a}")
+
+# tmdb_client can be None here as it shouldn't be used if tmdb_id is missing
+tmdb_client_for_test = TMDBClient() # Or None, but MovieDetailsWidget expects a client object or None
+mock_main_window_4a = MockMainWindow("Instance4a")
+poster_label_container_4a = QLabel() 
+
+widget_4a = MovieDetailsWidget(movie=movie_data_4_a.copy(), api_client=None, main_window=mock_main_window_4a, tmdb_client=tmdb_client_for_test, parent=poster_label_container_4a)
+print(f"[TEST_SCENARIO_4] Movie data after MovieDetailsWidget init (4a): {widget_4a.movie}")
+print(f"[TEST_SCENARIO_4] Poster label pixmap null after init (4a): {widget_4a.poster.pixmap().isNull()}")
+if 'stream_icon' not in widget_4a.movie or widget_4a.movie['stream_icon'] is None:
+    print("[TEST_SCENARIO_4] SUCCESS (4a): movie.stream_icon is not set.")
+else:
+    print(f"[TEST_SCENARIO_4] FAILURE (4a): movie.stream_icon was unexpectedly set to: {widget_4a.movie.get('stream_icon')}")
+
+print("\n[TEST_SCENARIO_4] --- Movie with no stream_icon and tmdb_id is None ---")
+movie_data_4_b = {
+    'name': 'Movie With tmdb_id as None',
+    'tmdb_id': None # Explicitly None
+}
+print(f"[TEST_SCENARIO_4] Initial movie_data_4_b: {movie_data_4_b}")
+
+mock_main_window_4b = MockMainWindow("Instance4b")
+poster_label_container_4b = QLabel() 
+
+widget_4b = MovieDetailsWidget(movie=movie_data_4_b.copy(), api_client=None, main_window=mock_main_window_4b, tmdb_client=tmdb_client_for_test, parent=poster_label_container_4b)
+print(f"[TEST_SCENARIO_4] Movie data after MovieDetailsWidget init (4b): {widget_4b.movie}")
+print(f"[TEST_SCENARIO_4] Poster label pixmap null after init (4b): {widget_4b.poster.pixmap().isNull()}")
+if 'stream_icon' not in widget_4b.movie or widget_4b.movie['stream_icon'] is None:
+    print("[TEST_SCENARIO_4] SUCCESS (4b): movie.stream_icon is not set.")
+else:
+    print(f"[TEST_SCENARIO_4] FAILURE (4b): movie.stream_icon was unexpectedly set to: {widget_4b.movie.get('stream_icon')}")
+
+print("[TEST_SCENARIO_4] END")
+


### PR DESCRIPTION
If a movie's poster (`stream_icon`) is initially missing, this change implements the following:

1.  The `MovieDetailsWidget` now attempts to fetch movie details from TMDB using the movie's `tmdb_id`.
2.  If a poster path is found on TMDB, the full poster URL is constructed (using a new helper in `TMDBClient`) and used to load the image.
3.  The `load_image_async` utility has been enhanced to download images from full HTTP(S) URLs (like TMDB's) using the `requests` library, in addition to its previous capability of using an API client for provider-specific image paths.
4.  The fetched TMDB poster URL is then stored back into the `movie['stream_icon']` field, so that subsequent uses or views of this movie item will use the fetched poster.
5.  The downloaded image is cached locally using the existing `ImageCache` mechanism, preventing repeated downloads for the same poster.
6.  If `tmdb_id` is missing, or if TMDB does not have a poster for the movie, the widget falls back to displaying the default placeholder image.

This ensures a richer experience for you by providing movie posters even when they are not available in the primary data source.